### PR TITLE
pygithub 1.38

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,49 +1,38 @@
 {% set name = "PyGithub" %}
-{% set version = "2.8.1" %}
+{% set version = "1.38" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: 341b7c78521cb07324ff670afd1baa2bf5c286f8d9fd302c1798ba594a5400c9
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1ed08f775ec5067bc8452b72bde2dbb95cf4e52ff2bd50cc32c69c91ffad9272
 
 build:
   number: 0
-  skip: true  # [py<38]
+  # Need to use setuptools <58.0 to avoid build error
+  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python
-    - setuptools >=64
-    - setuptools_scm >=7
+    - python 3.10
+    # use_2to3 is a deprecated
+    - setuptools <58.0
+    - wheel
   run:
-    - python
-    # pyjwt[crypto] is pyjwt + cryptography
-    - cryptography
-    - pyjwt >=2.4.0
-    - pynacl >=1.4.0
-    - urllib3 >=1.26.0
-    - requests >=2.14.0
-    - typing_extensions >=4.5.0
+    - python >=3.10
+    - pyjwt
 
 test:
-  source_files:
-    - tests
-    - pyproject.toml
   imports:
     - github
-  requires:
-    - pip
-    - pytest >=5.3
-    - httpretty >=1.0.3
-    - responses
   commands:
     - pip check
-    - pytest -v tests
+  requires:
+    - pip
 
 about:
   home: https://github.com/PyGithub/PyGithub


### PR DESCRIPTION
pygithub 1.38

### Links

- [PKG-14481](https://anaconda.atlassian.net/browse/PKG-14481_pygithub_1.38) 
- [Upstream repository](https://github.com/PyGithub/PyGithub/tree/v1.38)


### Explanation of changes:

- Build old version for aws-cli 2.85


[PKG-14481]: https://anaconda.atlassian.net/browse/PKG-14481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ